### PR TITLE
Refactor: Revert LLMImprovementResponse creation to LLMService

### DIFF
--- a/backend/app/api/endpoints/tasks.py
+++ b/backend/app/api/endpoints/tasks.py
@@ -1,17 +1,11 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, Path, Query, status
 from odmantic import ObjectId
 
 from app.api.schemas.llm import LLMImprovementRequest, LLMImprovementResponse
 from app.api.schemas.task import TaskCreateRequest, TaskPriority, TaskResponse, TaskStatus, TaskUpdateRequest
 from app.core.dependencies import get_current_active_user_id
-# LLMActionType removed as it's no longer used directly in this file
-from app.core.exceptions import (
-    LLMAPIKeyNotConfiguredError,
-    LLMGenerationError,
-    LLMServiceError,
-)
 from app.services.llm_service import LLMService
 from app.services.task_service import TaskService
 
@@ -86,20 +80,9 @@ async def improve_text_with_llm(
     Receives text and an action, and returns an LLM-generated improvement.
     This is a stateless endpoint that does not interact with any specific task in the database.
     """
-    try:
-        return await llm_service.process_llm_action(
-            action=request.action, title=request.title, description=request.description
-        )
-    except LLMAPIKeyNotConfiguredError as e:
-        raise HTTPException(status_code=500, detail=e.detail)
-    except LLMGenerationError as e:
-        raise HTTPException(status_code=500, detail=e.detail)
-    except LLMServiceError as e:
-        # Handle other LLMServiceErrors, potentially with their own status codes
-        raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except Exception as e:
-        # Catch-all for any other unexpected errors
-        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+    return await llm_service.process_llm_action(
+        action=request.action, title=request.title, description=request.description
+    )
 
 
 @router.get(

--- a/backend/app/api/endpoints/tasks.py
+++ b/backend/app/api/endpoints/tasks.py
@@ -5,7 +5,7 @@ from odmantic import ObjectId
 
 from app.api.schemas.llm import LLMImprovementRequest, LLMImprovementResponse
 from app.api.schemas.task import TaskCreateRequest, TaskPriority, TaskResponse, TaskStatus, TaskUpdateRequest
-from app.core.dependencies import get_current_active_user_id
+from app.core.dependencies import get_current_active_user_id, get_llm_service
 from app.services.llm_service import LLMService
 from app.services.task_service import TaskService
 
@@ -73,7 +73,7 @@ async def get_task_by_id(
 )
 async def improve_text_with_llm(
     request: LLMImprovementRequest,
-    llm_service: LLMService = Depends(LLMService),
+    llm_service: LLMService = Depends(get_llm_service),
     current_user_id: ObjectId = Depends(get_current_active_user_id),
 ):
     """

--- a/backend/app/clients/llm/base.py
+++ b/backend/app/clients/llm/base.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+
+
+class LLMClient(ABC):
+    @abstractmethod
+    async def generate_text(self, prompt: str) -> str:
+        pass

--- a/backend/app/clients/llm/google_gemini.py
+++ b/backend/app/clients/llm/google_gemini.py
@@ -1,0 +1,29 @@
+import google.generativeai as genai
+
+from app.clients.llm.base import LLMClient
+from app.core.config import settings
+from app.core.exceptions import LLMAPIKeyNotConfiguredError, LLMGenerationError
+
+
+class GoogleGeminiClient(LLMClient):
+    def __init__(self):
+        if not settings.LLM_API_KEY:
+            raise LLMAPIKeyNotConfiguredError()
+        genai.configure(api_key=settings.LLM_API_KEY)
+        self.model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gemini-2.5-flash-lite-preview-06-17"
+        self.model = genai.GenerativeModel(self.model_name)
+
+    async def generate_text(self, prompt: str) -> str:
+        try:
+            response = await self.model.generate_content_async(prompt)
+            if response.text:
+                suggestion = response.text.strip()
+                if suggestion.startswith("Error:"):
+                    raise LLMGenerationError(detail=suggestion)
+                return suggestion
+            else:
+                raise LLMGenerationError(detail="GoogleGemini API call failed to return valid text.")
+        except (genai.types.BlockedPromptException, genai.types.StopCandidateException) as e:
+            raise LLMGenerationError(detail=f"Google Gemini API error: {str(e)}")
+        except Exception as e:
+            raise LLMGenerationError(detail=f"An unexpected error occurred with Google Gemini: {str(e)}")

--- a/backend/app/clients/llm/openai.py
+++ b/backend/app/clients/llm/openai.py
@@ -1,0 +1,30 @@
+import openai
+
+from app.clients.llm.base import LLMClient
+from app.core.config import settings
+from app.core.exceptions import LLMAPIKeyNotConfiguredError, LLMGenerationError
+
+
+class OpenAIClient(LLMClient):
+    def __init__(self):
+        if not settings.LLM_API_KEY:
+            raise LLMAPIKeyNotConfiguredError()
+        self.client = openai.AsyncOpenAI(api_key=settings.LLM_API_KEY)
+        self.model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gpt-4.1-nano"
+
+    async def generate_text(self, prompt: str) -> str:
+        try:
+            response = await self.client.chat.completions.create(
+                model=self.model_name, messages=[{"role": "user", "content": prompt}]
+            )
+            if response.choices and response.choices[0].message and response.choices[0].message.content:
+                suggestion = response.choices[0].message.content.strip()
+                if suggestion.startswith("Error:"):
+                    raise LLMGenerationError(detail=suggestion)
+                return suggestion
+            else:
+                raise LLMGenerationError(detail="OpenAI API call failed to return a valid response.")
+        except openai.APIError as e:
+            raise LLMGenerationError(detail=f"OpenAI API error: {str(e)}")
+        except Exception as e:
+            raise LLMGenerationError(detail=f"An unexpected error occurred with OpenAI: {str(e)}")

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -296,3 +296,10 @@ class LLMAPIKeyNotConfiguredError(LLMServiceError):
 
     def __init__(self, detail: str = "LLM API key is not configured."):
         super().__init__(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=detail)
+
+
+class LLMInputValidationError(LLMServiceError):
+    """Raised when input validation for an LLM action fails."""
+
+    def __init__(self, detail: str):
+        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -91,7 +91,7 @@ async def error_handling_middleware(request: Request, call_next):
     except LLMServiceError as e:
         logger.error(f"LLMServiceError: {e.detail}")
         return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=e.status_code,
             content={"detail": e.detail},
         )
     except Exception as e:

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -11,6 +11,7 @@ from app.core.exceptions import (
     InvalidTokenException,
     LLMAPIKeyNotConfiguredError,
     LLMGenerationError,
+    LLMInputValidationError,
     LLMServiceError,
     TaskCategoryMismatchException,
     TaskDataMissingError,
@@ -65,6 +66,12 @@ async def error_handling_middleware(request: Request, call_next):
         )
     except TaskDataMissingError as e:
         logger.error(f"TaskDataMissingError: {e.detail}")
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"detail": e.detail},
+        )
+    except LLMInputValidationError as e:
+        logger.info(f"LLMInputValidationError: {e.detail}")
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content={"detail": e.detail},

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,22 +5,18 @@ from fastapi.middleware.cors import CORSMiddleware
 from motor.motor_asyncio import AsyncIOMotorClient
 from odmantic import AIOEngine
 
-from app.api.endpoints import categories, daily_plans, day_templates, tasks, users  # Uncommented daily_plans
-from app.core.config import settings  # Import settings
+from app.api.endpoints import categories, daily_plans, day_templates, tasks, users
+from app.core.config import settings
 from app.core.logging_config import setup_logging
 from app.core.middleware import error_handling_middleware
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Setup logging first
     setup_logging()
-
-    # Setup database connection
     app.state.motor_client = AsyncIOMotorClient(settings.MONGODB_URL)
     app.state.engine = AIOEngine(client=app.state.motor_client, database=settings.MONGODB_DATABASE_NAME)
     yield
-    # Cleanup
     app.state.motor_client.close()
 
 
@@ -28,25 +24,16 @@ app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.ALLOWED_ORIGINS,  # Use origins from settings
+    allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],  # Restrict methods
-    allow_headers=["Content-Type", "Authorization", "X-Requested-With"],  # Restrict headers
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+    allow_headers=["Content-Type", "Authorization", "X-Requested-With"],
 )
 
 app.middleware("http")(error_handling_middleware)
 
-# Include users router with API version prefix
 app.include_router(users.router, prefix=f"{settings.API_V1_STR}/users", tags=["users"])
-
-# Include day templates router with API version prefix
 app.include_router(day_templates.router, prefix=f"{settings.API_V1_STR}/day-templates", tags=["day-templates"])
-
-# Include categories router with API version prefix
 app.include_router(categories.router, prefix=f"{settings.API_V1_STR}/categories", tags=["categories"])
-
-# Include tasks router with API version prefix
 app.include_router(tasks.router, prefix=f"{settings.API_V1_STR}/tasks", tags=["tasks"])
-
-# Include daily plans router with API version prefix
-app.include_router(daily_plans.router, prefix=f"{settings.API_V1_STR}/daily-plans", tags=["daily-plans"])  # Uncommented
+app.include_router(daily_plans.router, prefix=f"{settings.API_V1_STR}/daily-plans", tags=["daily-plans"])

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -3,12 +3,87 @@ from typing import Optional
 import google.generativeai as genai
 import openai
 
+from app.api.schemas.llm import LLMImprovementResponse # Added back
 from app.core.config import settings
-from app.core.enums import LLMProvider
-from app.core.exceptions import LLMAPIKeyNotConfiguredError, LLMGenerationError, LLMServiceError
+from app.core.enums import LLMActionType, LLMProvider
+from app.core.exceptions import (
+    LLMAPIKeyNotConfiguredError,
+    LLMGenerationError,
+    LLMInputValidationError,
+    LLMServiceError,
+)
 
 
 class LLMService:
+
+    async def process_llm_action(
+        self, action: LLMActionType, title: Optional[str] = None, description: Optional[str] = None
+    ) -> LLMImprovementResponse: # Changed back to LLMImprovementResponse
+        text_to_improve = ""
+        base_prompt_override = None
+        response = LLMImprovementResponse()
+
+        match action:
+            case LLMActionType.IMPROVE_TITLE:
+                if not title:
+                    raise LLMInputValidationError("Title is required for 'improve_title' action.")
+                text_to_improve = title
+                base_prompt_override = "Improve the following task title to make it more concise and informative:"
+                improved_text = await self.improve_text(text_to_improve, base_prompt_override)
+                response.improved_title = improved_text
+            case LLMActionType.IMPROVE_DESCRIPTION:
+                if description is None:
+                    raise LLMInputValidationError("Description is required for 'improve_description' action.")
+                text_to_improve = description
+                base_prompt_override = "Improve the following task description to make it more concise and informative:"
+                improved_text = await self.improve_text(text_to_improve, base_prompt_override)
+                response.improved_description = improved_text
+            case LLMActionType.GENERATE_DESCRIPTION_FROM_TITLE:
+                if not title:
+                    raise LLMInputValidationError(
+                        "Title is required for 'generate_description_from_title' action."
+                    )
+                text_to_improve = f"Task Title: {title}"
+                base_prompt_override = (
+                    "Based on the following task title, generate a concise and informative task description:"
+                )
+                improved_text = await self.improve_text(text_to_improve, base_prompt_override)
+                response.improved_description = improved_text
+            case _:
+                # This case should ideally not be reached if action is validated at API level,
+                # but as a safeguard:
+                # Using LLMServiceError directly as this is not an input validation but an unknown state.
+                raise LLMServiceError(status_code=400, detail=f"Unknown or unsupported LLM action: {action}")
+
+        return response
+
+    async def _call_openai(self, full_prompt_for_llm: str) -> str:
+        openai_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gpt-3.5-turbo"
+        client = openai.AsyncOpenAI(api_key=settings.LLM_API_KEY)
+        response = await client.chat.completions.create(
+            model=openai_model_name, messages=[{"role": "user", "content": full_prompt_for_llm}]
+        )
+        if response.choices and response.choices[0].message and response.choices[0].message.content:
+            suggestion = response.choices[0].message.content.strip()
+            if suggestion.startswith("Error:"):
+                raise LLMGenerationError(detail=suggestion)
+            return suggestion
+        else:
+            raise LLMGenerationError(detail="OpenAI API call failed to return a valid response.")
+
+    async def _call_google_gemini(self, full_prompt_for_llm: str) -> str:
+        gemini_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gemini-pro"
+        genai.configure(api_key=settings.LLM_API_KEY)
+        model = genai.GenerativeModel(gemini_model_name)
+        response = await model.generate_content_async(full_prompt_for_llm)
+        # Ensure response.text is not None before stripping
+        if response.text:
+            suggestion = response.text.strip()
+            if suggestion.startswith("Error:"):
+                raise LLMGenerationError(detail=suggestion)
+            return suggestion
+        else:
+            raise LLMGenerationError(detail="GoogleGemini API call failed to return valid text.")
 
     async def improve_text(self, text_to_process: str, base_prompt_override: Optional[str] = None) -> str:
         if not settings.LLM_API_KEY:
@@ -20,35 +95,12 @@ class LLMService:
         full_prompt_for_llm = f"{prompt_to_use}\n\n---\n\n{text_to_process}"
 
         try:
-            match settings.LLM_PROVIDER:
-                case str(LLMProvider.OPENAI):
-                    openai_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gpt-3.5-turbo"
-                    client = openai.AsyncOpenAI(api_key=settings.LLM_API_KEY)
-                    response = await client.chat.completions.create(
-                        model=openai_model_name, messages=[{"role": "user", "content": full_prompt_for_llm}]
-                    )
-                    if response.choices and response.choices[0].message and response.choices[0].message.content:
-                        suggestion = response.choices[0].message.content.strip()
-                        if suggestion.startswith("Error:"):
-                            raise LLMGenerationError(detail=suggestion)
-                        return suggestion
-                    else:
-                        raise LLMGenerationError(detail="OpenAI API call failed to return a valid response.")
-                case str(LLMProvider.GOOGLE_GEMINI):
-                    gemini_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gemini-pro"
-                    genai.configure(api_key=settings.LLM_API_KEY)
-                    model = genai.GenerativeModel(gemini_model_name)
-                    response = await model.generate_content_async(full_prompt_for_llm)
-                    # Ensure response.text is not None before stripping
-                    if response.text:
-                        suggestion = response.text.strip()
-                        if suggestion.startswith("Error:"):
-                            raise LLMGenerationError(detail=suggestion)
-                        return suggestion
-                    else:
-                        raise LLMGenerationError(detail="GoogleGemini API call failed to return valid text.")
-                case _:
-                    raise LLMServiceError(status_code=500, detail=f"Unknown LLM_PROVIDER: {settings.LLM_PROVIDER}")
+            if settings.LLM_PROVIDER == str(LLMProvider.OPENAI):
+                return await self._call_openai(full_prompt_for_llm)
+            elif settings.LLM_PROVIDER == str(LLMProvider.GOOGLE_GEMINI):
+                return await self._call_google_gemini(full_prompt_for_llm)
+            else:
+                raise LLMServiceError(status_code=500, detail=f"Unknown LLM_PROVIDER: {settings.LLM_PROVIDER}")
 
         except (LLMGenerationError, LLMAPIKeyNotConfiguredError, LLMServiceError) as e:
             # Re-raise known exceptions directly
@@ -56,6 +108,7 @@ class LLMService:
         except (openai.APIError, genai.types.BlockedPromptException, genai.types.StopCandidateException) as e:
             raise LLMGenerationError(detail=f"LLM provider API error: {str(e)}")
         except Exception as e:
+            # Catch any other exceptions and wrap them in LLMServiceError
             raise LLMServiceError(
                 status_code=500, detail=f"An unexpected error occurred while contacting the LLM provider: {str(e)}"
             )

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,24 +1,19 @@
 from typing import Optional
 
-import google.generativeai as genai
-import openai
-
-from app.api.schemas.llm import LLMImprovementResponse # Added back
+from app.api.schemas.llm import LLMImprovementResponse
+from app.clients.llm.base import LLMClient
 from app.core.config import settings
-from app.core.enums import LLMActionType, LLMProvider
-from app.core.exceptions import (
-    LLMAPIKeyNotConfiguredError,
-    LLMGenerationError,
-    LLMInputValidationError,
-    LLMServiceError,
-)
+from app.core.enums import LLMActionType
+from app.core.exceptions import LLMGenerationError, LLMInputValidationError, LLMServiceError
 
 
 class LLMService:
+    def __init__(self, llm_client: LLMClient):
+        self.llm_client = llm_client
 
     async def process_llm_action(
         self, action: LLMActionType, title: Optional[str] = None, description: Optional[str] = None
-    ) -> LLMImprovementResponse: # Changed back to LLMImprovementResponse
+    ) -> LLMImprovementResponse:
         text_to_improve = ""
         base_prompt_override = None
         response = LLMImprovementResponse()
@@ -40,9 +35,7 @@ class LLMService:
                 response.improved_description = improved_text
             case LLMActionType.GENERATE_DESCRIPTION_FROM_TITLE:
                 if not title:
-                    raise LLMInputValidationError(
-                        "Title is required for 'generate_description_from_title' action."
-                    )
+                    raise LLMInputValidationError("Title is required for 'generate_description_from_title' action.")
                 text_to_improve = f"Task Title: {title}"
                 base_prompt_override = (
                     "Based on the following task title, generate a concise and informative task description:"
@@ -50,65 +43,19 @@ class LLMService:
                 improved_text = await self.improve_text(text_to_improve, base_prompt_override)
                 response.improved_description = improved_text
             case _:
-                # This case should ideally not be reached if action is validated at API level,
-                # but as a safeguard:
-                # Using LLMServiceError directly as this is not an input validation but an unknown state.
                 raise LLMServiceError(status_code=400, detail=f"Unknown or unsupported LLM action: {action}")
 
         return response
 
-    async def _call_openai(self, full_prompt_for_llm: str) -> str:
-        openai_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gpt-3.5-turbo"
-        client = openai.AsyncOpenAI(api_key=settings.LLM_API_KEY)
-        response = await client.chat.completions.create(
-            model=openai_model_name, messages=[{"role": "user", "content": full_prompt_for_llm}]
-        )
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            suggestion = response.choices[0].message.content.strip()
-            if suggestion.startswith("Error:"):
-                raise LLMGenerationError(detail=suggestion)
-            return suggestion
-        else:
-            raise LLMGenerationError(detail="OpenAI API call failed to return a valid response.")
-
-    async def _call_google_gemini(self, full_prompt_for_llm: str) -> str:
-        gemini_model_name = settings.LLM_MODEL_NAME if settings.LLM_MODEL_NAME else "gemini-pro"
-        genai.configure(api_key=settings.LLM_API_KEY)
-        model = genai.GenerativeModel(gemini_model_name)
-        response = await model.generate_content_async(full_prompt_for_llm)
-        # Ensure response.text is not None before stripping
-        if response.text:
-            suggestion = response.text.strip()
-            if suggestion.startswith("Error:"):
-                raise LLMGenerationError(detail=suggestion)
-            return suggestion
-        else:
-            raise LLMGenerationError(detail="GoogleGemini API call failed to return valid text.")
-
     async def improve_text(self, text_to_process: str, base_prompt_override: Optional[str] = None) -> str:
-        if not settings.LLM_API_KEY:
-            raise LLMAPIKeyNotConfiguredError()
-
         prompt_to_use = base_prompt_override or settings.LLM_TEXT_IMPROVEMENT_PROMPT
-        # Using a separator to clearly distinguish the instruction/prompt from the text to be processed.
-        # The specific separator "---" is arbitrary but clear.
         full_prompt_for_llm = f"{prompt_to_use}\n\n---\n\n{text_to_process}"
 
         try:
-            if settings.LLM_PROVIDER == str(LLMProvider.OPENAI):
-                return await self._call_openai(full_prompt_for_llm)
-            elif settings.LLM_PROVIDER == str(LLMProvider.GOOGLE_GEMINI):
-                return await self._call_google_gemini(full_prompt_for_llm)
-            else:
-                raise LLMServiceError(status_code=500, detail=f"Unknown LLM_PROVIDER: {settings.LLM_PROVIDER}")
-
-        except (LLMGenerationError, LLMAPIKeyNotConfiguredError, LLMServiceError) as e:
-            # Re-raise known exceptions directly
+            return await self.llm_client.generate_text(full_prompt_for_llm)
+        except LLMGenerationError as e:
             raise e
-        except (openai.APIError, genai.types.BlockedPromptException, genai.types.StopCandidateException) as e:
-            raise LLMGenerationError(detail=f"LLM provider API error: {str(e)}")
         except Exception as e:
-            # Catch any other exceptions and wrap them in LLMServiceError
             raise LLMServiceError(
                 status_code=500, detail=f"An unexpected error occurred while contacting the LLM provider: {str(e)}"
             )

--- a/backend/tests/clients/llm/test_llm_clients.py
+++ b/backend/tests/clients/llm/test_llm_clients.py
@@ -1,0 +1,159 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import google.generativeai as genai
+import openai
+import pytest
+
+from app.clients.llm.google_gemini import GoogleGeminiClient
+from app.clients.llm.openai import OpenAIClient
+from app.core.config import Settings
+from app.core.exceptions import LLMAPIKeyNotConfiguredError, LLMGenerationError
+
+
+@pytest.fixture
+def mock_settings_with_api_key():
+    with (
+        patch("app.clients.llm.openai.settings", spec=Settings) as mock_openai_settings,
+        patch("app.clients.llm.google_gemini.settings", spec=Settings) as mock_gemini_settings,
+    ):
+        mock_openai_settings.LLM_API_KEY = "test_openai_key"
+        mock_openai_settings.LLM_MODEL_NAME = "gpt-4.1-nano"
+        mock_gemini_settings.LLM_API_KEY = "test_gemini_key"
+        mock_gemini_settings.LLM_MODEL_NAME = "gemini-2.5-flash-lite-preview-06-17"
+        yield
+
+
+@pytest.fixture
+def mock_settings_without_api_key():
+    with (
+        patch("app.clients.llm.openai.settings", spec=Settings) as mock_openai_settings,
+        patch("app.clients.llm.google_gemini.settings", spec=Settings) as mock_gemini_settings,
+    ):
+        mock_openai_settings.LLM_API_KEY = ""
+        mock_gemini_settings.LLM_API_KEY = ""
+        yield
+
+
+class TestOpenAIClient:
+    async def test_initialization_success(self, mock_settings_with_api_key):
+        client = OpenAIClient()
+        assert client.client is not None
+        assert client.model_name == "gpt-4.1-nano"
+
+    async def test_initialization_no_api_key(self, mock_settings_without_api_key):
+        with pytest.raises(LLMAPIKeyNotConfiguredError):
+            OpenAIClient()
+
+    @patch("openai.AsyncOpenAI")
+    async def test_generate_text_success(self, mock_async_openai, mock_settings_with_api_key):
+        mock_client_instance = mock_async_openai.return_value
+        mock_client_instance.chat.completions.create = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=MagicMock(content="Generated text."))])
+        )
+        client = OpenAIClient()
+        result = await client.generate_text("Test prompt")
+        assert result == "Generated text."
+        mock_client_instance.chat.completions.create.assert_called_once_with(
+            model="gpt-4.1-nano", messages=[{"role": "user", "content": "Test prompt"}]
+        )
+
+    @patch("openai.AsyncOpenAI")
+    async def test_generate_text_api_error(self, mock_async_openai, mock_settings_with_api_key):
+        mock_client_instance = mock_async_openai.return_value
+        # Added 'body=None' to APIError instantiation
+        mock_client_instance.chat.completions.create.side_effect = openai.APIError("API Error", request=None, body=None)
+        client = OpenAIClient()
+        with pytest.raises(LLMGenerationError, match="OpenAI API error: API Error"):
+            await client.generate_text("Test prompt")
+
+    @patch("openai.AsyncOpenAI")
+    async def test_generate_text_empty_response(self, mock_async_openai, mock_settings_with_api_key):
+        mock_client_instance = mock_async_openai.return_value
+        mock_client_instance.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[]))
+        client = OpenAIClient()
+        with pytest.raises(LLMGenerationError, match="OpenAI API call failed to return a valid response."):
+            await client.generate_text("Test prompt")
+
+    @patch("openai.AsyncOpenAI")
+    async def test_generate_text_error_prefix_in_response(self, mock_async_openai, mock_settings_with_api_key):
+        mock_client_instance = mock_async_openai.return_value
+        mock_client_instance.chat.completions.create = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=MagicMock(content="Error: Something went wrong."))])
+        )
+        client = OpenAIClient()
+        with pytest.raises(LLMGenerationError, match="Error: Something went wrong."):
+            await client.generate_text("Test prompt")
+
+    @patch("openai.AsyncOpenAI")
+    async def test_generate_text_unexpected_exception(self, mock_async_openai, mock_settings_with_api_key):
+        mock_client_instance = mock_async_openai.return_value
+        mock_client_instance.chat.completions.create.side_effect = Exception("Unexpected error")
+        client = OpenAIClient()
+        with pytest.raises(LLMGenerationError, match="An unexpected error occurred with OpenAI: Unexpected error"):
+            await client.generate_text("Test prompt")
+
+
+class TestGoogleGeminiClient:
+    async def test_initialization_success(self, mock_settings_with_api_key):
+        with patch("google.generativeai.configure") as mock_configure:
+            client = GoogleGeminiClient()
+            assert client.model is not None
+            assert client.model_name == "gemini-2.5-flash-lite-preview-06-17"
+            mock_configure.assert_called_once_with(api_key="test_gemini_key")
+
+    async def test_initialization_no_api_key(self, mock_settings_without_api_key):
+        with pytest.raises(LLMAPIKeyNotConfiguredError):
+            GoogleGeminiClient()
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_success(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async = AsyncMock(return_value=MagicMock(text="Generated text."))
+        client = GoogleGeminiClient()
+        result = await client.generate_text("Test prompt")
+        assert result == "Generated text."
+        mock_model_instance.generate_content_async.assert_called_once_with("Test prompt")
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_blocked_prompt_exception(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async.side_effect = genai.types.BlockedPromptException("Blocked")
+        client = GoogleGeminiClient()
+        with pytest.raises(LLMGenerationError, match="Google Gemini API error: Blocked"):
+            await client.generate_text("Test prompt")
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_stop_candidate_exception(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async.side_effect = genai.types.StopCandidateException("Stopped")
+        client = GoogleGeminiClient()
+        with pytest.raises(LLMGenerationError, match="Google Gemini API error: Stopped"):
+            await client.generate_text("Test prompt")
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_empty_response(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async = AsyncMock(return_value=MagicMock(text=""))
+        client = GoogleGeminiClient()
+        with pytest.raises(LLMGenerationError, match="GoogleGemini API call failed to return valid text."):
+            await client.generate_text("Test prompt")
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_error_prefix_in_response(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async = AsyncMock(
+            return_value=MagicMock(text="Error: Something went wrong.")
+        )
+        client = GoogleGeminiClient()
+        with pytest.raises(LLMGenerationError, match="Error: Something went wrong."):
+            await client.generate_text("Test prompt")
+
+    @patch("google.generativeai.GenerativeModel")
+    async def test_generate_text_unexpected_exception(self, mock_generative_model, mock_settings_with_api_key):
+        mock_model_instance = mock_generative_model.return_value
+        mock_model_instance.generate_content_async.side_effect = Exception("Unexpected error")
+        client = GoogleGeminiClient()
+        with pytest.raises(
+            LLMGenerationError, match="An unexpected error occurred with Google Gemini: Unexpected error"
+        ):
+            await client.generate_text("Test prompt")

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -1,261 +1,130 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-import google.generativeai as genai
-import openai
 import pytest
 
+from app.clients.llm.base import LLMClient
+from app.clients.llm.google_gemini import GoogleGeminiClient
+from app.clients.llm.openai import OpenAIClient
 from app.core.config import Settings
-from app.core.exceptions import LLMAPIKeyNotConfiguredError, LLMGenerationError, LLMServiceError
+from app.core.exceptions import (
+    LLMAPIKeyNotConfiguredError,
+    LLMGenerationError,
+    LLMInputValidationError,
+    LLMServiceError,
+)
 from app.services.llm_service import LLMService
 
-# Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
 
 class TestLLMService:
+    @pytest.fixture
+    def mock_llm_client(self):
+        return AsyncMock(spec=LLMClient)
 
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_missing_api_key(self, mock_settings):
+    @pytest.fixture
+    def llm_service(self, mock_llm_client):
+        return LLMService(llm_client=mock_llm_client)
+
+    @patch("app.clients.llm.openai.settings", spec=Settings)
+    async def test_openai_client_missing_api_key(self, mock_settings):
         mock_settings.LLM_API_KEY = ""
-        mock_settings.LLM_PROVIDER = "OpenAI"  # Provider doesn't matter here
-        mock_settings.LLM_MODEL_NAME = ""  # Does not matter here
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Does not matter here"
-
-        service = LLMService()
-        service.settings = mock_settings  # Ensure service uses the mocked settings
-
         with pytest.raises(LLMAPIKeyNotConfiguredError):
-            await service.improve_text(text_to_process="some text")
+            OpenAIClient()
 
-    @patch("openai.AsyncOpenAI")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_openai_provider_success_default_prompt_and_model(
-        self, mock_settings, mock_async_openai_client
-    ):
-        mock_settings.LLM_PROVIDER = "OpenAI"
-        mock_settings.LLM_API_KEY = "fake_openai_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this:"
-        mock_settings.LLM_MODEL_NAME = ""  # Use default model
+    @patch("app.clients.llm.google_gemini.settings", spec=Settings)
+    async def test_google_gemini_client_missing_api_key(self, mock_settings):
+        mock_settings.LLM_API_KEY = ""
+        with pytest.raises(LLMAPIKeyNotConfiguredError):
+            GoogleGeminiClient()
 
-        mock_openai_instance = AsyncMock()
-        mock_chat_completions_create = AsyncMock()
-        mock_chat_completions_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content="Improved by OpenAI"))]
-        )
-        mock_openai_instance.chat.completions.create = mock_chat_completions_create
-        mock_async_openai_client.return_value = mock_openai_instance
+    async def test_improve_text_success_default_prompt(self, llm_service, mock_llm_client):
+        with patch("app.services.llm_service.settings", spec=Settings) as mock_settings:
+            mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this:"
+            mock_llm_client.generate_text.return_value = "Improved text"
 
-        service = LLMService()
-        service.settings = mock_settings
+            test_input = "test input"
+            result = await llm_service.improve_text(text_to_process=test_input)
 
-        test_input = "test input"
-        # Test with default prompt (no base_prompt_override)
-        result = await service.improve_text(text_to_process=test_input)
+            expected_full_prompt = f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\n{test_input}"
+            mock_llm_client.generate_text.assert_called_once_with(expected_full_prompt)
+            assert result == "Improved text"
 
-        mock_async_openai_client.assert_called_once_with(api_key="fake_openai_key")
-        expected_full_prompt = f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\n{test_input}"
-        mock_openai_instance.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo", messages=[{"role": "user", "content": expected_full_prompt}]  # Default model
-        )
-        assert result == "Improved by OpenAI"
-
-    @patch("openai.AsyncOpenAI")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_openai_provider_returns_error_string_raises_llm_generation_error(
-        self, mock_settings, mock_async_openai_client
-    ):
-        mock_settings.LLM_PROVIDER = "OpenAI"
-        mock_settings.LLM_API_KEY = "fake_openai_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this:"
-        mock_settings.LLM_MODEL_NAME = ""
-
-        mock_openai_instance = AsyncMock()
-        mock_chat_completions_create = AsyncMock()
-        mock_chat_completions_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content="Error: API key missing"))]
-        )
-        mock_openai_instance.chat.completions.create = mock_chat_completions_create
-        mock_async_openai_client.return_value = mock_openai_instance
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMGenerationError, match="Error: API key missing"):
-            await service.improve_text(text_to_process="test input")
-
-    @patch("openai.AsyncOpenAI")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_openai_provider_no_content_raises_llm_generation_error(
-        self, mock_settings, mock_async_openai_client
-    ):
-        mock_settings.LLM_PROVIDER = "OpenAI"
-        mock_settings.LLM_API_KEY = "fake_openai_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this:"
-        mock_settings.LLM_MODEL_NAME = ""
-
-        mock_openai_instance = AsyncMock()
-        mock_chat_completions_create = AsyncMock()
-        mock_chat_completions_create.return_value = MagicMock(choices=[MagicMock(message=MagicMock(content=None))])
-        mock_openai_instance.chat.completions.create = mock_chat_completions_create
-        mock_async_openai_client.return_value = mock_openai_instance
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMGenerationError, match="OpenAI API call failed to return a valid response."):
-            await service.improve_text(text_to_process="test input")
-
-    @patch("openai.AsyncOpenAI")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_openai_provider_custom_prompt_and_model(self, mock_settings, mock_async_openai_client):
-        mock_settings.LLM_PROVIDER = "OpenAI"
-        mock_settings.LLM_API_KEY = "fake_openai_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "This is default but should be overridden"
-        mock_settings.LLM_MODEL_NAME = "gpt-4-custom"
-
-        mock_openai_instance = AsyncMock()
-        mock_chat_completions_create = AsyncMock()
-        mock_chat_completions_create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content="Improved by Custom OpenAI"))]
-        )
-        mock_openai_instance.chat.completions.create = mock_chat_completions_create
-        mock_async_openai_client.return_value = mock_openai_instance
-
-        service = LLMService()
-        service.settings = mock_settings
+    async def test_improve_text_success_custom_prompt(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.return_value = "Improved by Custom Prompt"
 
         test_input = "custom test input"
         custom_prompt = "Custom override prompt:"
-        # Test with base_prompt_override
-        result = await service.improve_text(text_to_process=test_input, base_prompt_override=custom_prompt)
+        result = await llm_service.improve_text(text_to_process=test_input, base_prompt_override=custom_prompt)
 
-        mock_async_openai_client.assert_called_once_with(api_key="fake_openai_key")
         expected_full_prompt = f"{custom_prompt}\n\n---\n\n{test_input}"
-        mock_openai_instance.chat.completions.create.assert_called_once_with(
-            model="gpt-4-custom", messages=[{"role": "user", "content": expected_full_prompt}]  # Custom model
-        )
-        assert result == "Improved by Custom OpenAI"
+        mock_llm_client.generate_text.assert_called_once_with(expected_full_prompt)
+        assert result == "Improved by Custom Prompt"
 
-    @patch("google.generativeai.GenerativeModel")
-    @patch("google.generativeai.configure")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_google_gemini_provider_success_default_prompt_and_model(
-        self, mock_settings, mock_genai_configure, mock_genai_model
-    ):
-        mock_settings.LLM_PROVIDER = "GoogleGemini"
-        mock_settings.LLM_API_KEY = "fake_gemini_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this gem:"
-        mock_settings.LLM_MODEL_NAME = ""  # Use default model
+    async def test_improve_text_llm_generation_error(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.side_effect = LLMGenerationError(detail="LLM failed")
 
-        mock_gemini_instance = AsyncMock()
-        mock_gemini_instance.generate_content_async.return_value = MagicMock(text="Improved by Gemini")
-        mock_genai_model.return_value = mock_gemini_instance
+        with pytest.raises(LLMGenerationError, match="LLM failed"):
+            await llm_service.improve_text(text_to_process="some text")
 
-        service = LLMService()
-        service.settings = mock_settings
+    async def test_improve_text_unexpected_error(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.side_effect = Exception("Unexpected error")
 
-        test_input = "gemini test"
-        result = await service.improve_text(text_to_process=test_input)  # Default prompt
+        with pytest.raises(
+            LLMServiceError, match="An unexpected error occurred while contacting the LLM provider: Unexpected error"
+        ):
+            await llm_service.improve_text(text_to_process="some text")
 
-        mock_genai_configure.assert_called_once_with(api_key="fake_gemini_key")
-        mock_genai_model.assert_called_once_with("gemini-pro")  # Default model
-        expected_full_prompt = f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\n{test_input}"
-        mock_gemini_instance.generate_content_async.assert_called_once_with(expected_full_prompt)
-        assert result == "Improved by Gemini"
+    async def test_process_llm_action_improve_title_success(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.return_value = "Improved Title"
+        with patch("app.services.llm_service.settings", spec=Settings) as mock_settings:
+            mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = (
+                "Improve the following task title to make it more concise and informative:"
+            )
+            response = await llm_service.process_llm_action(action="improve_title", title="Old Title")
+            assert response.improved_title == "Improved Title"
+            mock_llm_client.generate_text.assert_called_once_with(
+                f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\nOld Title"
+            )
 
-    @patch("google.generativeai.GenerativeModel")
-    @patch("google.generativeai.configure")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_google_gemini_provider_returns_error_string_raises_llm_generation_error(
-        self, mock_settings, mock_genai_configure, mock_genai_model
-    ):
-        mock_settings.LLM_PROVIDER = "GoogleGemini"
-        mock_settings.LLM_API_KEY = "fake_gemini_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this gem:"
-        mock_settings.LLM_MODEL_NAME = ""
+    async def test_process_llm_action_improve_title_no_title(self, llm_service):
+        with pytest.raises(LLMInputValidationError, match="Title is required for 'improve_title' action."):
+            await llm_service.process_llm_action(action="improve_title")
 
-        mock_gemini_instance = AsyncMock()
-        mock_gemini_instance.generate_content_async.return_value = MagicMock(text="Error: Gemini API Error")
-        mock_genai_model.return_value = mock_gemini_instance
+    async def test_process_llm_action_improve_description_success(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.return_value = "Improved Description"
+        with patch("app.services.llm_service.settings", spec=Settings) as mock_settings:
+            mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = (
+                "Improve the following task description to make it more concise and informative:"
+            )
+            response = await llm_service.process_llm_action(action="improve_description", description="Old Description")
+            assert response.improved_description == "Improved Description"
+            mock_llm_client.generate_text.assert_called_once_with(
+                f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\nOld Description"
+            )
 
-        service = LLMService()
-        service.settings = mock_settings
+    async def test_process_llm_action_improve_description_no_description(self, llm_service):
+        with pytest.raises(LLMInputValidationError, match="Description is required for 'improve_description' action."):
+            await llm_service.process_llm_action(action="improve_description")
 
-        with pytest.raises(LLMGenerationError, match="Error: Gemini API Error"):
-            await service.improve_text(text_to_process="gemini test")
+    async def test_process_llm_action_generate_description_from_title_success(self, llm_service, mock_llm_client):
+        mock_llm_client.generate_text.return_value = "Generated Description"
+        with patch("app.services.llm_service.settings", spec=Settings) as mock_settings:
+            mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = (
+                "Based on the following task title, generate a concise and informative task description:"
+            )
+            response = await llm_service.process_llm_action(action="generate_description_from_title", title="New Task")
+            assert response.improved_description == "Generated Description"
+            mock_llm_client.generate_text.assert_called_once_with(
+                f"{mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT}\n\n---\n\nTask Title: New Task"
+            )
 
-    @patch("google.generativeai.GenerativeModel")
-    @patch("google.generativeai.configure")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_google_gemini_provider_no_content_raises_llm_generation_error(
-        self, mock_settings, mock_genai_configure, mock_genai_model
-    ):
-        mock_settings.LLM_PROVIDER = "GoogleGemini"
-        mock_settings.LLM_API_KEY = "fake_gemini_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this gem:"
-        mock_settings.LLM_MODEL_NAME = ""
+    async def test_process_llm_action_generate_description_from_title_no_title(self, llm_service):
+        with pytest.raises(
+            LLMInputValidationError, match="Title is required for 'generate_description_from_title' action."
+        ):
+            await llm_service.process_llm_action(action="generate_description_from_title")
 
-        mock_gemini_instance = AsyncMock()
-        mock_gemini_instance.generate_content_async.return_value = MagicMock(text=None)
-        mock_genai_model.return_value = mock_gemini_instance
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMGenerationError, match="GoogleGemini API call failed to return valid text."):
-            await service.improve_text(text_to_process="gemini test")
-
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_unknown_provider(self, mock_settings):
-        mock_settings.LLM_PROVIDER = "UnknownProvider"
-        mock_settings.LLM_API_KEY = "fake_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "This prompt does not matter for this test"
-        mock_settings.LLM_MODEL_NAME = ""
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMServiceError) as excinfo:
-            await service.improve_text(text_to_process="some text")
-        assert "Unknown LLM_PROVIDER: UnknownProvider" in str(excinfo.value.detail)
-
-    @patch("openai.AsyncOpenAI")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_openai_api_error(self, mock_settings, mock_async_openai_client):
-        mock_settings.LLM_PROVIDER = "OpenAI"
-        mock_settings.LLM_API_KEY = "fake_openai_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this:"
-        mock_settings.LLM_MODEL_NAME = ""
-
-        mock_openai_instance = AsyncMock()
-        mock_openai_instance.chat.completions.create.side_effect = openai.APIError(
-            "OpenAI API Error", request=MagicMock(), body=MagicMock()
-        )
-        mock_async_openai_client.return_value = mock_openai_instance
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMGenerationError) as excinfo:
-            await service.improve_text(text_to_process="test input")
-        assert "LLM provider API error: OpenAI API Error" in str(excinfo.value.detail)
-
-    @patch("google.generativeai.GenerativeModel")
-    @patch("google.generativeai.configure")
-    @patch("app.services.llm_service.settings", spec=Settings)
-    async def test_improve_text_google_gemini_api_error(self, mock_settings, mock_genai_configure, mock_genai_model):
-        mock_settings.LLM_PROVIDER = "GoogleGemini"
-        mock_settings.LLM_API_KEY = "fake_gemini_key"
-        mock_settings.LLM_TEXT_IMPROVEMENT_PROMPT = "Improve this gem:"
-        mock_settings.LLM_MODEL_NAME = ""
-
-        mock_gemini_instance = AsyncMock()
-        mock_gemini_instance.generate_content_async.side_effect = genai.types.BlockedPromptException("Gemini API Error")
-        mock_genai_model.return_value = mock_gemini_instance
-
-        service = LLMService()
-        service.settings = mock_settings
-
-        with pytest.raises(LLMGenerationError) as excinfo:
-            await service.improve_text(text_to_process="gemini test")
-        assert "LLM provider API error: Gemini API Error" in str(excinfo.value.detail)
+    async def test_process_llm_action_unknown_action(self, llm_service):
+        with pytest.raises(LLMServiceError, match="Unknown or unsupported LLM action: unknown_action"):
+            await llm_service.process_llm_action(action="unknown_action")


### PR DESCRIPTION
Based on your feedback, this commit reverts the handling of LLMImprovementResponse objects.

Changes include:
- `LLMService.process_llm_action` now constructs and returns the `LLMImprovementResponse` object directly, instead of a tuple.
- The `tasks.py` endpoint `improve_text_with_llm` has been updated to directly return the `LLMImprovementResponse` received from the service, removing the local construction logic.
- Associated import changes for `LLMImprovementResponse` and `LLMActionType` have been made in the respective files.

Service-level tests confirm that `LLMService` correctly handles the response object creation. API-level testing for this specific flow remains affected by external MongoDB environment issues.