### PR TITLE
feat: Implement centralized stop task logic

### DIFF
--- a/frontend/src/context/SharedTimerContext.tsx
+++ b/frontend/src/context/SharedTimerContext.tsx
@@ -44,6 +44,7 @@ interface SharedTimerContextType {
   setCurrentTaskId: React.Dispatch<React.SetStateAction<string | undefined>>;
   setCurrentTaskName: React.Dispatch<React.SetStateAction<string | undefined>>;
   setOnTaskComplete: React.Dispatch<React.SetStateAction<((taskId: string, taskData: TaskUpdateRequest) => Promise<Task>) | undefined>>;
+  stopCurrentTask: () => void;
 }
 
 const SharedTimerContext = createContext<SharedTimerContextType | undefined>(undefined);
@@ -56,6 +57,20 @@ export const SharedTimerProvider: React.FC<{ children: ReactNode }> = ({ childre
   const [currentTaskId, setCurrentTaskId] = useState<string | undefined>(undefined);
   const [currentTaskName, setCurrentTaskName] = useState<string | undefined>(undefined);
   const [onTaskComplete, setOnTaskComplete] = useState<((taskId: string, taskData: TaskUpdateRequest) => Promise<Task>) | undefined>(undefined);
+
+  const stopCurrentTask = async () => {
+    if (currentTaskId && onTaskComplete) {
+      try {
+        await onTaskComplete(currentTaskId, { status: 'PENDING' });
+      } catch (error) {
+        console.error("Failed to update task status to PENDING:", error);
+        // Optionally, handle the error more gracefully (e.g., show a notification to the user)
+      }
+    }
+    setCurrentTaskId(undefined);
+    setCurrentTaskName(undefined);
+    setOnTaskComplete(undefined);
+  };
 
   const handleTaskCompletion = useCallback(async () => {
     if (currentTaskId && onTaskComplete) {
@@ -168,6 +183,7 @@ export const SharedTimerProvider: React.FC<{ children: ReactNode }> = ({ childre
     setCurrentTaskId,
     setCurrentTaskName,
     setOnTaskComplete,
+    stopCurrentTask,
   };
 
   return (


### PR DESCRIPTION
Adds a new `stopCurrentTask` function to the `SharedTimerContext`.

This function provides a centralized way to handle task interruptions. When called, it:
- Checks if a `currentTaskId` and `onTaskComplete` callback exist.
- If so, it calls `onTaskComplete` (which is expected to trigger an `updateTask` mutation) to set the task's status to `PENDING`.
- Clears `currentTaskId`, `currentTaskName`, and `onTaskComplete` from the context state.

This change centralizes the logic for stopping a task, preventing code duplication and ensuring consistent behavior across the UI.